### PR TITLE
Update articlescontainer.class.php to allow using numbers at start of tag to be treated still as tag

### DIFF
--- a/core/components/articles/model/articles/articlescontainer.class.php
+++ b/core/components/articles/model/articles/articlescontainer.class.php
@@ -322,7 +322,10 @@ class ArticlesContainer extends modResource {
         $where = array('class_key' => 'Article');
         if (!empty($_REQUEST['arc_author'])) {
             $userPk = $this->xpdo->sanitizeString($_REQUEST['arc_author']);
-            if (intval($userPk) == 0) {
+            if (function_exists(filter_var)) {
+                $userPkNum = filter_var($userPk,FILTER_VALIDATE_INT);
+            } else { $userPkNum = intval($userPk); }
+            if ($userPkNum == 0) {
                 /** @var modUser $user */
                 $user = $this->xpdo->getObject('modUser',array('username' => $userPk));
                 if ($user) {

--- a/core/components/articles/model/articles/articlescontainer.class.php
+++ b/core/components/articles/model/articles/articlescontainer.class.php
@@ -322,7 +322,7 @@ class ArticlesContainer extends modResource {
         $where = array('class_key' => 'Article');
         if (!empty($_REQUEST['arc_author'])) {
             $userPk = $this->xpdo->sanitizeString($_REQUEST['arc_author']);
-            if (function_exists(filter_var)) {
+            if (function_exists('filter_var')) {
                 $userPkNum = filter_var($userPk,FILTER_VALIDATE_INT);
             } else { $userPkNum = intval($userPk); }
             if ($userPkNum == 0) {


### PR DESCRIPTION
Changed to use filter_var when available so tags/strings that start with a number are still evaluated false as an int vs showing as a full int and being treated as a user id.

Currently if a tag starts with a number it is treated as a user id due to have intval casts. As filter_var was added later than MODX min requirements, added conditional logic to maintain backwards compatibility but allow proper validation in future versions. 
