### PR TITLE
Remove static html code from code

### DIFF
--- a/assets/components/articles/js/container/container.common.js
+++ b/assets/components/articles/js/container/container.common.js
@@ -1616,7 +1616,7 @@ Ext.extend(Articles.panel.ContainerTemplateSettings,MODx.Panel,{
             ,height: 250
             ,grow: false
             ,border: false
-            ,value: config.record && config.record.content ? config.record.content : "[[+articles]]\n\n[[+paging]]"
+            ,value: config.record && config.record.content ? config.record.content : "[[+articles]]\n\n[[!+page.nav:notempty=`\n<div class='paging'>\n\t<ul class='pageList'>\n\t\t[[+paging]]\n\t</ul>\n</div>\n`]]"
         },{
             id: 'modx-content-below'
             ,border: false

--- a/core/components/articles/model/articles/articlescontainer.class.php
+++ b/core/components/articles/model/articles/articlescontainer.class.php
@@ -372,13 +372,7 @@ class ArticlesContainer extends modResource {
         ]]';
         $this->xpdo->setPlaceholder($placeholderPrefix.'articles',$output);
 
-        $this->xpdo->setPlaceholder($placeholderPrefix.'paging','[[!+page.nav:notempty=`
-<div class="paging">
-<ul class="pageList">
-  [[!+page.nav]]
-</ul>
-</div>
-`]]');
+        $this->xpdo->setPlaceholder($placeholderPrefix.'paging','[[!+page.nav]]');
         return $output;
     }
 


### PR DESCRIPTION
this is a fix for this issue: https://github.com/modxcms/Articles/issues/42. 

It moves the static container around paging elements into the content area, where it can be freely edited.
