### PR TITLE
Add setting for default published status of new article

### DIFF
--- a/assets/components/articles/js/container/container.common.js
+++ b/assets/components/articles/js/container/container.common.js
@@ -68,6 +68,16 @@ Articles.panel.ContainerAdvancedSettings = function(config) {
 
             },{
                 xtype: 'combo-boolean'
+                ,name: 'setting_articlesPublished'
+                ,hiddenName: 'setting_articlesPublished'
+                ,id: 'articles-published'
+                ,fieldLabel: _('resource_published')
+                ,description: MODx.expandHelp ? '' : _('resource_published_help') + ' ' + _('articles.setting.published_desc')
+                ,width: 120
+                ,listeners: oc
+                ,value: 1
+            },{
+                xtype: 'combo-boolean'
                 ,name: 'setting_articlesRichtext'
                 ,hiddenName: 'setting_articlesRichtext'
                 ,id: 'articles-richtext'

--- a/core/components/articles/controllers/article/create.class.php
+++ b/core/components/articles/controllers/article/create.class.php
@@ -75,7 +75,6 @@ class ArticleCreateManagerController extends ResourceCreateManagerController {
 
     public function process(array $scriptProperties = array()) {
         $placeholders = parent::process($scriptProperties);
-        $this->resourceArray['published'] = 0;
         $this->getDefaultContainerSettings();
         return $placeholders;
     }
@@ -89,6 +88,7 @@ class ArticleCreateManagerController extends ResourceCreateManagerController {
             $settings = $container->getProperties('articles');
             $this->resourceArray['template'] = $this->modx->getOption('articleTemplate',$settings,0);
             $this->resourceArray['richtext'] = $this->modx->getOption('articlesRichtext',$settings,1);
+            $this->resourceArray['published'] = $this->modx->getOption('articlesPublished',$settings,0);
         }
     }
 }

--- a/core/components/articles/lexicon/en/default.inc.php
+++ b/core/components/articles/lexicon/en/default.inc.php
@@ -132,6 +132,7 @@ $_lang['none'] = 'None';
 /* General */
 $_lang['articles.setting.updateServicesEnabled'] = 'Enable Update Services';
 $_lang['articles.setting.updateServicesEnabled_desc'] = 'If on, Articles will attempt to ping Ping-o-Matic whenever you publish an Article, to send out your article\'s title and URL to major search engines.';
+$_lang['articles.setting.published_desc'] = 'Default published status for new articles.';
 $_lang['articles.setting.richtext_desc'] = 'Once created, individual Articles can override this value.';
 $_lang['articles.setting.sortBy'] = 'Sort Field';
 $_lang['articles.setting.sortBy_desc'] = 'The field to sort by on the main and archives listing pages.';


### PR DESCRIPTION
I came upon a case where the customer wanted new articles to be published by default, and the system setting didn't seem to apply to articles. So I added a setting to the container.
Maybe it should default to the system setting, or maybe just use that instead in the first place?
