### PR TITLE
Update articletemplate default Author

### DIFF
--- a/core/components/articles/elements/templates/articletemplate.tpl
+++ b/core/components/articles/elements/templates/articletemplate.tpl
@@ -38,7 +38,7 @@
 <div id="main" class="grid_12">
     <h2 class="title"><a href="[[~[[*id]]]]">[[*pagetitle]]</a></h2>
     <p class="post-info">
-        <span class="left">Posted on [[*publishedon:strtotime:date=`%b %d, %Y`]] by <a href="[[~[[*parent]]]]author/[[*publishedby:userinfo=`username`]]">[[*publishedby:userinfo=`username`]]</a></span>
+     <span class="left">Posted on [[*publishedon:strtotime:date=`%b %d, %Y`]] by <a href="[[~[[*parent]]]]author/[[*createdby:userinfo=`username`]]">[[*createdby:userinfo=`username`]]</a></span>
 [[*articlestags:notempty=`
         <span class="tags left">&nbsp;| Tags: [[+article_tags]]</span>
 `]]


### PR DESCRIPTION
Internally we have cases where we publish content on behalf of the client. The current configuration unfortunately shows the created-by name in the container, but then shows the editors name in the actual article.

This has really bugged me - Why is the default set to show the persons name who 'published' the article and not the 'person who wrote it'? I imagine that most content writers would want credit for their work; not the editor. This pull request changes the post author to the same person as "created by" in the article, effectively giving the author the credit, not the editor.
