### PR TITLE
Added 404 page if no resource is found and the default resource is selected

### DIFF
--- a/core/components/articles/model/articles/articlesrouter.class.php
+++ b/core/components/articles/model/articles/articlesrouter.class.php
@@ -96,9 +96,14 @@ class ArticlesRouter {
         } else {
             /* set Archivist parameters for date-based archives */
 
-            $_REQUEST[$prefix.'year'] = $_GET[$prefix.'year'] = $params[0];
-            if (isset($params[1])) $_REQUEST[$prefix.'month'] = $_GET[$prefix.'month'] = $params[1];
-            if (isset($params[2])) $_REQUEST[$prefix.'day'] = $_GET[$prefix.'day'] = $params[2];
+             if(is_numeric($params[0])) {
+                 $_REQUEST[$prefix.'year'] = $_GET[$prefix.'year'] = $params[0];
+                 if (isset($params[1])) $_REQUEST[$prefix.'month'] = $_GET[$prefix.'month'] = $params[1];
+                 if (isset($params[2])) $_REQUEST[$prefix.'day'] = $_GET[$prefix.'day'] = $params[2];
+             } else {
+                // Display the default 404 page if nothing found
+                $this->modx->sendForward($this->modx->getOption('error_page'), 'HTTP/1.1 404 Not Found');
+             }
         }
 
         /* forward */


### PR DESCRIPTION
We were seeing 200 response codes from urls such as:

/news/this-doesnt-exist/

where /news/ is the Articles container.

This fix allows us to throw a 404 if the first $params is not a number (so Archivist still functions as normal)
