### PR TITLE
Add compatibility with ContentBlocks 1.1 for Articles

### DIFF
--- a/assets/components/articles/js/article/create.js
+++ b/assets/components/articles/js/article/create.js
@@ -126,6 +126,7 @@ Ext.extend(Articles.panel.Article,MODx.panel.Resource,{
             ,height: 400
             ,grow: false
             ,value: (config.record.content || config.record.ta) || ''
+            ,itemCls: 'contentblocks_replacement'
         },{
             id: 'modx-content-below'
             ,border: false

--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -305,6 +305,7 @@ Ext.extend(Articles.panel.Article,MODx.panel.Resource,{
             ,height: 400
             ,grow: false
             ,value: (config.record.content || config.record.ta) || ''
+            ,itemCls: 'contentblocks_replacement'
         },{
             id: 'modx-content-below'
             ,border: false


### PR DESCRIPTION
This patch adds a contentblocks_replacement class to the right element in the DOM so that ContentBlocks 1.1 can enhance the Article content with all the awesome that is ContentBlocks. 
