### PR TITLE
Fix processor not found error on Article update

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -28,7 +28,7 @@ set_time_limit(0);
 /* define package */
 define('PKG_NAME','Articles');
 define('PKG_NAME_LOWER',strtolower(PKG_NAME));
-define('PKG_VERSION','1.7.7');
+define('PKG_VERSION','1.7.8');
 define('PKG_RELEASE','pl');
 
 /* define sources */

--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -15,7 +15,7 @@ Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
         var btns = [];
         if (cfg.canSave == 1) {
             btns.push({
-                process: 'update'
+                process: (MODx.config.connector_url) ? 'resource/update' : 'update'
                 ,text: _('save')
                 ,method: 'remote'
                 ,checkDirty: cfg.richtext || MODx.request.activeSave == 1 ? false : true

--- a/core/components/articles/docs/changelog.txt
+++ b/core/components/articles/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for Articles.
 
+Articles 1.7.8
+===============================
+- #92 Fix Articles save on update in Revolution 2.3
+
 Articles 1.7.7
 ===============================
 - #90 Fix Articles in Revolution 2.3


### PR DESCRIPTION
Closes modxcms/Articles#92

Advising a 1.7.8 patch release with this fix, as saving Articles is currently borked in 2.3
