### PR TITLE
Updated getlist to be multibyte safe and article update getButtons override change

### DIFF
--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -10,13 +10,19 @@ Articles.page.UpdateArticle = function(config) {
     Articles.page.UpdateArticle.superclass.constructor.call(this,config);
 };
 Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
-
-    getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
+	doesButtonExist: function(btnArray, lexiconKey) {
+		var exists = false;
+		btnArray.map(function(item) {
+			if(lexiconKey == item.text) exists = true;
+		});
+		return exists;
+	}
+    ,getButtons: function(cfg) {
+        var btns = MODx.page.UpdateResource.prototype.getButtons(cfg); //[];
+        if (cfg.canSave == 1 && !this.doesButtonExist(btns, _('save'))) {
             btns.push({
                 process: (MODx.config.connector_url) ? 'resource/update' : 'update'
-                ,text: _('save')
+                ,text:_('save')
                 ,method: 'remote'
                 ,checkDirty: cfg.richtext || MODx.request.activeSave == 1 ? false : true
                 ,keys: [{
@@ -25,7 +31,7 @@ Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
                 }]
             });
             btns.push('-');
-        } else if (cfg.locked) {
+        } else if (cfg.locked && !this.doesButtonExist(btns, _('locked'))) {
             btns.push({
                 text: cfg.lockedText || _('locked')
                 ,handler: Ext.emptyFn
@@ -33,38 +39,54 @@ Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
             });
             btns.push('-');
         }
-        btns.push({
-            text: _('articles.article_publish')
-            ,id: 'modx-article-publish'
-            ,hidden: cfg.record.published ? true : false
-            ,handler: this.publishArticle
-        });
-        btns.push({
-            text: _('articles.article_unpublish')
-            ,id: 'modx-article-unpublish'
-            ,hidden: cfg.record.published ? false : true
-            ,handler: this.unpublishArticle
-        });
-        btns.push('-');
-        btns.push({
-            process: 'preview'
-            ,text: _('view')
-            ,handler: this.preview
-            ,scope: this
-        });
-        btns.push('-');
-        btns.push({
-            process: 'cancel'
-            ,text: _('cancel')
-            ,handler: this.cancel
-            ,scope: this
-        });
-        btns.push('-');
-        btns.push({
-            text: _('help_ex')
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
+	    if(cfg.publish_document && !this.doesButtonExist(btns, _('articles.article_publish'))) {
+	        btns.push({
+	            text: _('articles.article_publish')
+	            ,id: 'modx-article-publish'
+	            ,hidden: cfg.record.published ? true : false
+	            ,handler: this.publishArticle
+	        });
+	        btns.push({
+	            text: _('articles.article_unpublish')
+	            ,id: 'modx-article-unpublish'
+	            ,hidden: cfg.record.published ? false : true
+	            ,handler: this.unpublishArticle
+	        });
+		    btns.push('-');
+	    }
+		if(!this.doesButtonExist(btns, _('view'))) {
+	        btns.push({
+	            process: 'preview'
+	            ,text: _('view')
+	            ,handler: this.preview
+	            ,scope: this
+	        });
+	        btns.push('-');
+		}
+		if(!this.doesButtonExist(btns, _('cancel'))) {
+	        btns.push({
+	            process: 'cancel'
+	            ,text: _('cancel')
+	            ,handler: this.cancel
+	            ,scope: this
+	        });
+	        btns.push('-');
+		}
+		if(!this.doesButtonExist(btns, _('help_ex'))) {
+	        btns.push({
+	            text: _('help_ex')
+	            ,handler: MODx.loadHelpPane
+	        });
+		}
+
+		// remove duplicate spacings
+		for(var i=0; i<=(btns.length - 1); i++) {
+			var item = btns[i];
+			if(item != '-') continue;
+			if(btns[i+1] == '-' || (btns[i+1] && btns[i+1].hidden == true)) btns.splice(i,1);
+		}
+
+		return btns;
     }
 
     ,publishArticle: function(btn,e) {

--- a/core/components/articles/model/articles/article.class.php
+++ b/core/components/articles/model/articles/article.class.php
@@ -72,9 +72,9 @@ class Article extends modResource {
         $settings = $this->getProperties('articles');
         /** @var ArticlesContainer $container */
         $container = $this->getOne('Container');
-        if ($container) {
-            $settings = $container->getContainerSettings();
-        }
+		if(method_exists($container, 'getContainerSettings')) {
+			$settings = $container->getContainerSettings();
+		}
         return is_array($settings) ? $settings : array();
     }
 
@@ -257,7 +257,9 @@ class Article extends modResource {
             return false;
         }
 
-        $settings = $container->getContainerSettings();
+	    if(method_exists($container, 'getContainerSettings')) {
+		    $settings = $container->getContainerSettings();
+	    }
 
         if($this->get('pub_date')) $date = $this->get('pub_date');
         else $date = $this->get('published') ? $this->get('publishedon') : $this->get('createdon');

--- a/core/components/articles/processors/article/getlist.class.php
+++ b/core/components/articles/processors/article/getlist.class.php
@@ -235,9 +235,9 @@ class ArticleGetListProcessor extends modObjectGetListProcessor {
     }
 
     public function ellipsis($string,$length = 300) {
-        if (strlen($string) > $length) {
-            $string = substr($string,0,$length).'...';
-        }
+	    if (mb_strlen($string) > $length) {
+		    $string = mb_substr($string,0,$length,$this->modx->config['charset']).'...';
+	    }
         return $string;
     }
 }


### PR DESCRIPTION
currently the processor does not support any multi byte strings (Chinese under a utf8 charset) and no results return in the grid view.

Using the mb_\* functions with the correct charset resolves the issue.

Also updated the update.js getButtons function to correctly load any existing buttons and replace them rather than creating there own buttons. This allows any Extras to add additional buttons to the articles page without any hacks.
