### PR TITLE
Updated view/close buttons to work correctly with the overriding

### DIFF
--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -21,7 +21,7 @@ Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
     ,getButtons: function(cfg) {
 		var btns = MODx.page.UpdateResource.prototype.getButtons(cfg); //[];
 
-        if (cfg.canSave == 1 && !this.doesButtonExist(btns, _('save'))) {
+        if (cfg.canSave == 1 && this.doesButtonExist(btns, _('save') === false)) {
             btns.push({
                 process: (MODx.config.connector_url) ? 'resource/update' : 'update'
                 ,text: _('save')

--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -11,14 +11,16 @@ Articles.page.UpdateArticle = function(config) {
 };
 Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
 	doesButtonExist: function(btnArray, lexiconKey) {
-		var exists = false;
+		var exists = false, _k = 0;
 		btnArray.map(function(item) {
-			if(lexiconKey == item.text) exists = true;
+			if(lexiconKey == item.text) exists = _k;
+			_k++;
 		});
 		return exists;
 	}
     ,getButtons: function(cfg) {
-        var btns = [];
+		var btns = MODx.page.UpdateResource.prototype.getButtons(cfg); //[];
+
         if (cfg.canSave == 1 && !this.doesButtonExist(btns, _('save'))) {
             btns.push({
                 process: (MODx.config.connector_url) ? 'resource/update' : 'update'
@@ -55,24 +57,35 @@ Ext.extend(Articles.page.UpdateArticle,MODx.page.UpdateResource,{
 	        });
 		    btns.push('-');
 	    }
-		if(!this.doesButtonExist(btns, _('view'))) {
-	        btns.push({
-	            process: 'preview'
-	            ,text: _('view')
-	            ,handler: this.preview
-	            ,scope: this
-	        });
-	        btns.push('-');
+
+		var _view = {
+			process: 'preview'
+			,text: _('view')
+			,handler: this.preview
+			,scope: this
+		}, _idx = this.doesButtonExist(btns, _('view'));
+
+		if(!_idx) {
+			btns.push(_view);
+			btns.push('-');
+		} else {
+			btns.splice(_idx,1, _view);
 		}
-		if(!this.doesButtonExist(btns, _('cancel'))) {
-	        btns.push({
-	            process: 'cancel'
-	            ,text: _('cancel')
-	            ,handler: this.cancel
-	            ,scope: this
-	        });
-	        btns.push('-');
+
+		var _cnl = {
+			process: 'cancel'
+			,text: _('cancel')
+			,handler: this.cancel
+			,scope: this
+		}, _idx = this.doesButtonExist(btns, _('cancel'));
+
+		if(!_idx) {
+			btns.push(_cnl);
+			btns.push('-');
+		} else {
+			btns.splice(_idx,1, _cnl);
 		}
+
 		if(!this.doesButtonExist(btns, _('help_ex'))) {
 	        btns.push({
 	            text: _('help_ex')


### PR DESCRIPTION
In #103 we updated the update.js file to use the correct overriding function to get buttons from the parent ExtJS component rather than starting with a blank array.

Subsequently issue #104 reverted this change because the view and close buttons were not working as expected.

As the `Articles.page.UpdateArticle` ExtJS component is extending `MODx.page.UpdateResource` (and in turn replace the parent getButtons() function) it should get the parent buttons and replace them.

I have updated the getButtons function within update.js to correctly get the parent array of buttons and then overwrite the "view" and "close" buttons with the article ones so they work correctly.
