### PR TITLE
Fix memory exception when getting tags

### DIFF
--- a/core/components/articles/processors/extras/gettags.class.php
+++ b/core/components/articles/processors/extras/gettags.class.php
@@ -18,7 +18,7 @@ class ArticleExtrasGetTagsProcessor extends modObjectGetListProcessor {
             return false;
         }
 
-        $articleIDs = $this->modx->getChildIds($parent->id,6,array('context' => 'web'));
+        $articleIDs = $this->modx->getChildIds($parent->id,6,array('context' => $parent->get('context_key')));
 
         $templateVariable = $this->modx->getObject('modTemplateVar', array('name' => 'articlestags'));
         if(!$templateVariable){

--- a/core/components/articles/processors/extras/gettags.class.php
+++ b/core/components/articles/processors/extras/gettags.class.php
@@ -18,11 +18,7 @@ class ArticleExtrasGetTagsProcessor extends modObjectGetListProcessor {
             return false;
         }
 
-        $articles = $parent->getMany('Children',array('deleted' => 0));
-        $articleIDs = array();
-        foreach($articles as $article){
-            $articleIDs[] = $article->id;
-        }
+        $articleIDs = $this->modx->getChildIds($parent->id,6,array('context' => 'web'));
 
         $templateVariable = $this->modx->getObject('modTemplateVar', array('name' => 'articlestags'));
         if(!$templateVariable){


### PR DESCRIPTION
If there are allot of articles the get tags processor fires an memory exception > 500MB.

This can be fixed by getting the ID's directly instead of getting all the article objects.

Would be great if you could add this to the next version.