### PR TITLE
Fix the tag filtering with integer values

### DIFF
--- a/core/components/articles/model/articles/articlesrouter.class.php
+++ b/core/components/articles/model/articles/articlesrouter.class.php
@@ -80,7 +80,7 @@ class ArticlesRouter {
 
         /* tag handling! */
         if ($params[0] == 'tags') {
-            $_REQUEST[$prefix.'author'] = $_GET['tag'] = urldecode($params[1]);
+            $_REQUEST[$prefix.'tag'] = $_GET['tag'] = urldecode($params[1]);
         /* author based */
         } else if ($params[0] == 'user' || $params[0] == 'author') {
             $_REQUEST[$prefix.'author'] = $_GET[$prefix.'author'] = urldecode($params[1]);


### PR DESCRIPTION
Issue: If tag value is integer i.e. 50 or 550 or something
then the container page returns nothing but it works for all
other types of tag values.