### PR TITLE
Remove getContentField() override for Article update/create forms.

### DIFF
--- a/assets/components/articles/js/article/create.js
+++ b/assets/components/articles/js/article/create.js
@@ -122,27 +122,6 @@ Ext.extend(Articles.panel.Article,MODx.panel.Resource,{
         return mlf;
     }
 
-    ,getContentField: function(config) {
-        return [{
-            id: 'modx-content-above'
-            ,border: false
-        },{
-            xtype: 'textarea'
-            ,fieldLabel: _('articles.article_content')
-            ,name: 'ta'
-            ,id: 'ta'
-            ,anchor: '100%'
-            ,height: 400
-            ,grow: false
-            ,value: (config.record.content || config.record.ta) || ''
-            ,itemCls: 'contentblocks_replacement'
-        },{
-            id: 'modx-content-below'
-            ,border: false
-        }];
-    }
-
-
     ,getMainRightFields: function(config) {
         config = config || {};
 

--- a/assets/components/articles/js/article/update.js
+++ b/assets/components/articles/js/article/update.js
@@ -341,35 +341,12 @@ Ext.extend(Articles.panel.Article,MODx.panel.Resource,{
             ,value: config.record.introtext || ''
         });
 
-
-
         var ct = this.getContentField(config);
         if (ct) {
             mlf.push(ct);
         }
         return mlf;
     }
-
-    ,getContentField: function(config) {
-        return [{
-            id: 'modx-content-above'
-            ,border: false
-        },{
-            xtype: 'textarea'
-            ,fieldLabel: _('articles.article_content')
-            ,name: 'ta'
-            ,id: 'ta'
-            ,anchor: '100%'
-            ,height: 400
-            ,grow: false
-            ,value: (config.record.content || config.record.ta) || ''
-            ,itemCls: 'contentblocks_replacement'
-        },{
-            id: 'modx-content-below'
-            ,border: false
-        }];
-    }
-
 
     ,getMainRightFields: function(config) {
         config = config || {};


### PR DESCRIPTION
### What does it do?
Removes the `getContentField()` override method from Article update/create forms. 

### Why is it needed?
There's a bug when using ContentBlocks and switching tabs or resizing the browser window. It unhides the original content field. This is happening because the MODX 3 layout structure has changed, but Articles hasn't.
ContentBlocks was updated for MODX 3, and the `,itemCls: 'contentblocks_replacement'` property is no longer needed, so we can safely fall back to the core method.

