### PR TITLE
Fix charset in getlist processor

### DIFF
--- a/core/components/articles/src/Processors/Article/GetList.php
+++ b/core/components/articles/src/Processors/Article/GetList.php
@@ -231,7 +231,8 @@ class GetList extends GetListProcessor {
 
     public function ellipsis($string,$length = 300) {
 	    if (mb_strlen($string) > $length) {
-		    $string = mb_substr($string,0,$length,$this->modx->config['charset']).'...';
+            $encoding = $this->modx->getOption('modx_charset',null,'UTF-8');
+            $string = mb_substr($string,0,$length,$encoding).'...';
 	    }
         return $string;
     }


### PR DESCRIPTION
### What does it do?
Reads the charset value from the setting `modx_charset` instead of `charset`.

### Why is it needed?
The setting `charset` seems to be the database charset. If "utf8mb4" is used in the database, the code throws a fatal error
```
Fatal error: Uncaught ValueError: mb_substr(): Argument #4 ($encoding) must be a valid encoding, "utf8mb4" given
```
in PHP 8 (and outputs a `Unknown encoding "utf8mb4"` warning in PHP 7.4).

### Related issue(s)/PR(s)
Fixes #164
