### PR TITLE
[3.x] Fix "Import Articles" from MODX

### DIFF
--- a/core/components/articles/src/Model/Import/ArticlesImportModx.php
+++ b/core/components/articles/src/Model/Import/ArticlesImportModx.php
@@ -7,7 +7,7 @@ use Articles\Model\ArticlesContainer;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\modTemplateVarResource;
 use MODX\Revolution\modX;
-use MODX\Revolution\mysql\modResource;
+use MODX\Revolution\modResource;
 use quipThread;
 use xPDO\Om\xPDOQuery;
 

--- a/core/components/articles/src/Processors/Container/Import.php
+++ b/core/components/articles/src/Processors/Container/Import.php
@@ -57,12 +57,12 @@ class Import extends ModelProcessor {
     public function getImportService() {
         $serviceName = $this->getProperty('service','WordPress');
 
-        $modelPath = $this->modx->getOption('articles.core_path',null,$this->modx->getOption('core_path').'components/articles/').'model/articles/';
-        $servicePath = $modelPath.'import/articlesimport'.strtolower($serviceName).'.class.php';
+        $modelPath = $this->modx->getOption('articles.core_path',null,$this->modx->getOption('core_path').'components/articles/') . 'src/Model/';
+        $servicePath = $modelPath . 'Import/ArticlesImport' . ucfirst(strtolower($serviceName)) . '.php';
         if (file_exists($servicePath)) {
             require_once $servicePath;
             $className = ArticlesImport::class.$serviceName;
-            $this->service = new $className($this->modx->articles,$this,$this->getProperties());
+            $this->service = new $className(new \Articles\Articles($this->modx),$this,$this->getProperties());
         }
 
         return $this->service;


### PR DESCRIPTION
### Why is it needed?
The import process (Button "Import Articles" in the container) is broken.

---

* The code looks for the import classes in the wrong folder. (The files werde moved for the 3.x version.)
* `$this->modx->articles` is `null` because the MODX connector is used (and not the Articles connector that sets this property).

https://github.com/modxcms/Articles/blob/dc84f0847a08084a3db881c7bc74311e0cd50df1/assets/components/articles/js/container/articles.import.window.js#L11-L12

https://github.com/modxcms/Articles/blob/dc84f0847a08084a3db881c7bc74311e0cd50df1/assets/components/articles/connector.php#L37

### Related issue(s)/PR(s)
Forum topic: https://community.modx.com/t/articles-will-not-import-from-modx/7882
