### PR TITLE
[3.x] Remove modAction error message

### DIFF
--- a/core/components/articles/controllers/container/update.class.php
+++ b/core/components/articles/controllers/container/update.class.php
@@ -32,6 +32,7 @@ class ArticlesContainerUpdateManagerController extends ResourceUpdateManagerCont
     /** @var boolean $commentsEnabled */
     public $commentsEnabled = false;
     public function loadCustomCssJs() {
+        $settings = $this->resource->getContainerSettings();
         if ($this->modx->getOption('commentsEnabled',$settings,false)) {
             $quipCorePath = $this->modx->getOption('quip.core_path',null,$this->modx->getOption('core_path',null,MODX_CORE_PATH).'components/quip/');
             if ($this->modx->addPackage('quip',$quipCorePath.'model/')) {
@@ -67,7 +68,7 @@ class ArticlesContainerUpdateManagerController extends ResourceUpdateManagerCont
             });
             </script>');
         }
-        $settings = $this->resource->getContainerSettings();
+
         $this->resourceArray['articles_container_settings'] = $settings;
         
         $this->addHtml('

--- a/core/components/articles/src/Processors/Article/GetList.php
+++ b/core/components/articles/src/Processors/Article/GetList.php
@@ -35,17 +35,17 @@ class GetList extends GetListProcessor {
     public function initialize() {
 
         // @todo: we need an alternative to modAction as it no longer exists!
+        $this->editAction = 'resource/update';
+        if ($this->modx->getVersionData()['version'] < 3) {
+            $action = $this->modx->getObject('modAction', [
+                'namespace' => 'core',
+                'controller' => 'resource/update',
+            ]);
+            if ($action) {
+                $this->editAction = $action->get('id');
+            }
+        }
 
-        $action = $this->modx->getObject('modAction', [
-            'namespace' => 'core',
-            'controller' => 'resource/update',
-        ]);
-        if ($action) {
-            $this->editAction = $action->get('id');
-        }
-        else {
-            $this->editAction = 'resource/update';
-        }
         $this->defaultSortField = $this->modx->getOption('articles.default_article_sort_field',null,'createdon');
 
         if ($this->getParentContainer()) {


### PR DESCRIPTION
### Why is it needed?
In MODX 3, error messages get logged to the MODX error log every time the articles in a container are loaded.

```
Could not load class: modAction from mysql.modaction
modAction::load() is not a valid static method.
```
I added a check for the MODX version. Maybe the `modAction` code can be removed completely, if this version of the extra is only for MODX 3.

---

With PHP 8 there is a warning `PHP warning: Undefined variable $settings`.
I moved the line up that defines `$settings`.

### Related issue(s)/PR(s)
Forum post: https://community.modx.com/t/articles-problem-on-upgrade-to-3-0-4/7482/13
